### PR TITLE
Make provider requests outside the main thread raise an error

### DIFF
--- a/lib/neovim/ruby_provider.rb
+++ b/lib/neovim/ruby_provider.rb
@@ -1,15 +1,26 @@
 $__ruby_provider_scope = binding
+Thread.abort_on_exception = true
 
 class VIM < BasicObject
   class << self
     attr_accessor :__client
+    attr_writer :__parent_thread
   end
 
   Buffer = ::Neovim::Buffer
   Window = ::Neovim::Window
 
+  self.__parent_thread = ::Thread.current
+
   def self.method_missing(method, *args, &block)
-    @__client.public_send(method, *args, &block)
+    if @__parent_thread == ::Thread.current
+      @__client.public_send(method, *args, &block)
+    else
+      raise(
+        "A Ruby plugin attempted to call neovim outside of the main thread, " +
+        "which is not yet supported by the neovim gem."
+      )
+    end
   end
 end
 

--- a/spec/acceptance/ruby_provider_spec.rb
+++ b/spec/acceptance/ruby_provider_spec.rb
@@ -97,6 +97,20 @@ RSpec.describe "ruby_provider" do
       nvim.eval("rpcrequest(host, 'ruby_execute', 'foo')")
       expect(nvim.get_var("called")).to be(1)
     end
+
+    it "fails on multithreaded requests" do
+      ruby = <<-RUBY.inspect
+        VIM.command("let g:parent_var = 1")
+        Thread.new { VIM.command("let g:thread_var = 2") }.join
+      RUBY
+
+      expect {
+        nvim.eval("rpcrequest(host, 'ruby_execute', #{ruby})")
+      }.to raise_error(/failed to evaluate expression/i)
+
+      expect(nvim.get_var("parent_var")).to be(1)
+      expect { nvim.get_var("thread_var") }.to raise_error(/key not found/i)
+    end
   end
 
   describe "ruby_execute_file" do
@@ -190,6 +204,20 @@ RSpec.describe "ruby_provider" do
 
       nvim.eval("rpcrequest(host, 'ruby_execute', 'foo')")
       expect(nvim.get_var("called")).to be(1)
+    end
+
+    it "fails on multithreaded requests" do
+      File.write(script_path, <<-RUBY)
+        VIM.command("let g:parent_var = 1")
+        Thread.new { VIM.command("let g:thread_var = 2") }.join
+      RUBY
+
+      expect {
+        nvim.eval("rpcrequest(host, 'ruby_execute_file', '#{script_path}')")
+      }.to raise_error(/failed to evaluate expression/i)
+
+      expect(nvim.get_var("parent_var")).to be(1)
+      expect { nvim.get_var("thread_var") }.to raise_error(/key not found/i)
     end
   end
 


### PR DESCRIPTION
Since Ruby Fibers can't be coordinated across threads, we will likely need to make some dramatic changes to support multithreaded access to neovim inside ruby scripts. In the meantime, this just writes an error message when a request is made outside the parent thread.