### PR TITLE
Ensure Buffer#append maintains cursor position

### DIFF
--- a/lib/neovim/buffer.rb
+++ b/lib/neovim/buffer.rb
@@ -93,14 +93,21 @@ module Neovim
 
     # Append a line after the given line (1-indexed).
     #
+    # To maintain backwards compatibility with +vim+, the cursor is forced back
+    # to its previous position after inserting the line.
+    #
     # @param index [Fixnum]
     # @param str [String]
     # @return [String]
     def append(index, str)
+      window = @session.request(:vim_get_current_window)
+      cursor = window.cursor
+
       if index < 0
         raise ArgumentError, "Index out of bounds"
       else
-        insert(index, [str])
+        set_lines(index, index, true, [str])
+        window.set_cursor(cursor)
       end
       str
     end

--- a/spec/neovim/buffer_spec.rb
+++ b/spec/neovim/buffer_spec.rb
@@ -118,6 +118,12 @@ module Neovim
           }.to change { buffer.lines.to_a }.to(["one", "two", ""])
         end
 
+        it "leaves the cursor unchanged" do
+          expect {
+            buffer.append(0, "one")
+          }.not_to change { client.current.window.cursor }
+        end
+
         it "raises for out of bounds indexes" do
           expect {
             buffer.append(-1, "err")


### PR DESCRIPTION
This is for Vim `:ruby` compatibility.