### PR TITLE
disable ShaDa when running tests

### DIFF
--- a/spec/acceptance/neovim-ruby-host_spec.rb
+++ b/spec/acceptance/neovim-ruby-host_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "neovim-ruby-host" do
       end
     RUBY
 
-    nvim = Neovim.attach_child(["nvim", "-u", "NONE", "-n"])
+    nvim = Neovim.attach_child(["nvim", "-i", "NONE", "-u", "NONE", "-n"])
 
     nvim.command("let host = rpcstart('#{host_exe}', ['#{plugin_path}'])")
 

--- a/spec/acceptance/neovim-ruby-host_spec.rb
+++ b/spec/acceptance/neovim-ruby-host_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "neovim-ruby-host" do
       end
     RUBY
 
-    nvim = Neovim.attach_child(["nvim", "-i", "NONE", "-u", "NONE", "-n"])
+    nvim = Neovim.attach_child(Support.child_argv)
 
     nvim.command("let host = rpcstart('#{host_exe}', ['#{plugin_path}'])")
 

--- a/spec/acceptance/ruby_provider_spec.rb
+++ b/spec/acceptance/ruby_provider_spec.rb
@@ -2,7 +2,7 @@ require "helper"
 
 RSpec.describe "ruby_provider" do
   let!(:nvim) do
-    Neovim.attach_child(["nvim", "-u", "NONE", "-n"])
+    Neovim.attach_child(["nvim", "-i", "NONE", "-u", "NONE", "-n"])
   end
 
   around do |spec|

--- a/spec/acceptance/ruby_provider_spec.rb
+++ b/spec/acceptance/ruby_provider_spec.rb
@@ -2,7 +2,7 @@ require "helper"
 
 RSpec.describe "ruby_provider" do
   let!(:nvim) do
-    Neovim.attach_child(["nvim", "-i", "NONE", "-u", "NONE", "-n"])
+    Neovim.attach_child(Support.child_argv)
   end
 
   around do |spec|

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -10,7 +10,7 @@ if ENV["REPORT_COVERAGE"]
   Coveralls.wear!
 end
 
-unless system("nvim -nu NONE +q")
+unless system("nvim -i NONE -u NONE -n +q")
   warn("Can't find `nvim` executable. See installation instructions:")
   warn("https://github.com/neovim/neovim/wiki/Installing-Neovim")
   exit(1)

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -10,7 +10,43 @@ if ENV["REPORT_COVERAGE"]
   Coveralls.wear!
 end
 
-unless system("nvim -i NONE -u NONE -n +q")
+module Support
+  def self.workspace
+    File.expand_path("../workspace", __FILE__)
+  end
+
+  def self.socket_path
+    file_path("nvim.sock")
+  end
+
+  def self.port
+    server = TCPServer.new("0.0.0.0", 0)
+
+    begin
+      server.addr[1]
+    ensure
+      server.close
+    end
+  end
+
+  def self.file_path(name)
+    File.join(workspace, name)
+  end
+
+  def self.setup_workspace
+    FileUtils.mkdir_p(workspace)
+  end
+
+  def self.teardown_workspace
+    FileUtils.rm_rf(workspace)
+  end
+
+  def self.child_argv
+    ["nvim", "-i", "NONE", "-u", "NONE", "-n"]	
+  end
+end
+
+unless system("#{Support.child_argv.join(" ")} +q")
   warn("Can't find `nvim` executable. See installation instructions:")
   warn("https://github.com/neovim/neovim/wiki/Installing-Neovim")
   exit(1)
@@ -47,38 +83,6 @@ RSpec.configure do |config|
   end
 
   Kernel.srand config.seed
-end
-
-module Support
-  def self.workspace
-    File.expand_path("../workspace", __FILE__)
-  end
-
-  def self.socket_path
-    file_path("nvim.sock")
-  end
-
-  def self.port
-    server = TCPServer.new("0.0.0.0", 0)
-
-    begin
-      server.addr[1]
-    ensure
-      server.close
-    end
-  end
-
-  def self.file_path(name)
-    File.join(workspace, name)
-  end
-
-  def self.setup_workspace
-    FileUtils.mkdir_p(workspace)
-  end
-
-  def self.teardown_workspace
-    FileUtils.rm_rf(workspace)
-  end
 end
 
 Thread.abort_on_exception = true

--- a/spec/neovim/buffer_spec.rb
+++ b/spec/neovim/buffer_spec.rb
@@ -2,7 +2,7 @@ require "helper"
 
 module Neovim
   RSpec.describe Buffer do
-    let(:client) { Neovim.attach_child(["nvim", "-n", "-u", "NONE"]) }
+    let(:client) { Neovim.attach_child(["nvim", "-i", "NONE", "-u", "NONE", "-n"]) }
     let(:buffer) { client.current.buffer }
     after { client.shutdown }
 

--- a/spec/neovim/buffer_spec.rb
+++ b/spec/neovim/buffer_spec.rb
@@ -2,7 +2,7 @@ require "helper"
 
 module Neovim
   RSpec.describe Buffer do
-    let(:client) { Neovim.attach_child(["nvim", "-i", "NONE", "-u", "NONE", "-n"]) }
+    let(:client) { Neovim.attach_child(Support.child_argv) }
     let(:buffer) { client.current.buffer }
     after { client.shutdown }
 

--- a/spec/neovim/client_spec.rb
+++ b/spec/neovim/client_spec.rb
@@ -2,7 +2,7 @@ require "helper"
 
 module Neovim
   RSpec.describe Client do
-    let(:client) { Neovim.attach_child(["nvim", "-i", "NONE", "-u", "NONE", "-n"]) }
+    let(:client) { Neovim.attach_child(Support.child_argv) }
     after { client.shutdown }
 
     specify do

--- a/spec/neovim/client_spec.rb
+++ b/spec/neovim/client_spec.rb
@@ -2,7 +2,7 @@ require "helper"
 
 module Neovim
   RSpec.describe Client do
-    let(:client) { Neovim.attach_child(["nvim", "-n", "-u", "NONE"]) }
+    let(:client) { Neovim.attach_child(["nvim", "-i", "NONE", "-u", "NONE", "-n"]) }
     after { client.shutdown }
 
     specify do

--- a/spec/neovim/current_spec.rb
+++ b/spec/neovim/current_spec.rb
@@ -2,7 +2,7 @@ require "helper"
 
 module Neovim
   RSpec.describe Current do
-    let(:client) { Neovim.attach_child(["nvim", "-i", "NONE", "-u", "NONE", "-n"]) }
+    let(:client) { Neovim.attach_child(Support.child_argv) }
     let(:current) { client.current }
     after { client.shutdown }
 

--- a/spec/neovim/current_spec.rb
+++ b/spec/neovim/current_spec.rb
@@ -2,7 +2,7 @@ require "helper"
 
 module Neovim
   RSpec.describe Current do
-    let(:client) { Neovim.attach_child(["nvim", "-n", "-u", "NONE"]) }
+    let(:client) { Neovim.attach_child(["nvim", "-i", "NONE", "-u", "NONE", "-n"]) }
     let(:current) { client.current }
     after { client.shutdown }
 

--- a/spec/neovim/line_range_spec.rb
+++ b/spec/neovim/line_range_spec.rb
@@ -2,7 +2,7 @@ require "helper"
 
 module Neovim
   RSpec.describe LineRange do
-    let(:client) { Neovim.attach_child(["nvim", "-n", "-u", "NONE"]) }
+    let(:client) { Neovim.attach_child(["nvim", "-i", "NONE", "-u", "NONE", "-n"]) }
     let(:buffer) { client.current.buffer }
     let(:line_range) { LineRange.new(buffer, 0, -1) }
     let(:sub_range) { LineRange.new(buffer, 1, 2) }

--- a/spec/neovim/line_range_spec.rb
+++ b/spec/neovim/line_range_spec.rb
@@ -2,7 +2,7 @@ require "helper"
 
 module Neovim
   RSpec.describe LineRange do
-    let(:client) { Neovim.attach_child(["nvim", "-i", "NONE", "-u", "NONE", "-n"]) }
+    let(:client) { Neovim.attach_child(Support.child_argv) }
     let(:buffer) { client.current.buffer }
     let(:line_range) { LineRange.new(buffer, 0, -1) }
     let(:sub_range) { LineRange.new(buffer, 1, 2) }

--- a/spec/neovim/remote_object_spec.rb
+++ b/spec/neovim/remote_object_spec.rb
@@ -2,7 +2,7 @@ require "helper"
 
 module Neovim
   RSpec.describe RemoteObject do
-    let(:client) { Neovim.attach_child(["nvim", "-n", "-u", "NONE"]) }
+    let(:client) { Neovim.attach_child(["nvim", "-i", "NONE", "-u", "NONE", "-n"]) }
     after { client.shutdown }
 
     context Window do

--- a/spec/neovim/remote_object_spec.rb
+++ b/spec/neovim/remote_object_spec.rb
@@ -2,7 +2,7 @@ require "helper"
 
 module Neovim
   RSpec.describe RemoteObject do
-    let(:client) { Neovim.attach_child(["nvim", "-i", "NONE", "-u", "NONE", "-n"]) }
+    let(:client) { Neovim.attach_child(Support.child_argv) }
     after { client.shutdown }
 
     context Window do

--- a/spec/neovim/ruby_provider/buffer_ext_spec.rb
+++ b/spec/neovim/ruby_provider/buffer_ext_spec.rb
@@ -4,7 +4,7 @@ require "neovim/ruby_provider/buffer_ext"
 module Neovim
   RSpec.describe Buffer do
     let!(:nvim) do
-      Neovim.attach_child(["nvim", "-i", "NONE", "-u", "NONE", "-n"]).tap do |nvim|
+      Neovim.attach_child(Support.child_argv).tap do |nvim|
         stub_const("::VIM", nvim)
       end
     end

--- a/spec/neovim/ruby_provider/buffer_ext_spec.rb
+++ b/spec/neovim/ruby_provider/buffer_ext_spec.rb
@@ -4,7 +4,7 @@ require "neovim/ruby_provider/buffer_ext"
 module Neovim
   RSpec.describe Buffer do
     let!(:nvim) do
-      Neovim.attach_child(["nvim", "-u", "NONE", "-n"]).tap do |nvim|
+      Neovim.attach_child(["nvim", "-i", "NONE", "-u", "NONE", "-n"]).tap do |nvim|
         stub_const("::VIM", nvim)
       end
     end

--- a/spec/neovim/ruby_provider/window_ext_spec.rb
+++ b/spec/neovim/ruby_provider/window_ext_spec.rb
@@ -4,7 +4,7 @@ require "neovim/ruby_provider/window_ext"
 module Neovim
   RSpec.describe Window do
     let!(:nvim) do
-      Neovim.attach_child(["nvim", "-u", "NONE", "-n"]).tap do |nvim|
+      Neovim.attach_child(["nvim", "-i", "NONE", "-u", "NONE", "-n"]).tap do |nvim|
         stub_const("::VIM", nvim)
       end
     end

--- a/spec/neovim/ruby_provider/window_ext_spec.rb
+++ b/spec/neovim/ruby_provider/window_ext_spec.rb
@@ -4,7 +4,7 @@ require "neovim/ruby_provider/window_ext"
 module Neovim
   RSpec.describe Window do
     let!(:nvim) do
-      Neovim.attach_child(["nvim", "-i", "NONE", "-u", "NONE", "-n"]).tap do |nvim|
+      Neovim.attach_child(Support.child_argv).tap do |nvim|
         stub_const("::VIM", nvim)
       end
     end

--- a/spec/neovim/session/event_loop_spec.rb
+++ b/spec/neovim/session/event_loop_spec.rb
@@ -82,7 +82,7 @@ module Neovim
 
       context "child" do
         it "sends and receives data" do
-          event_loop = EventLoop.child(["nvim", "-i", "NONE", "-u", "NONE", "-n"])
+          event_loop = EventLoop.child(Support.child_argv)
           input = MessagePack.pack([0, 0, :vim_strwidth, ["hi"]])
 
           response = nil

--- a/spec/neovim/session/event_loop_spec.rb
+++ b/spec/neovim/session/event_loop_spec.rb
@@ -82,7 +82,7 @@ module Neovim
 
       context "child" do
         it "sends and receives data" do
-          event_loop = EventLoop.child(["nvim", "-n", "-u", "NONE"])
+          event_loop = EventLoop.child(["nvim", "-i", "NONE", "-u", "NONE", "-n"])
           input = MessagePack.pack([0, 0, :vim_strwidth, ["hi"]])
 
           response = nil

--- a/spec/neovim/session_spec.rb
+++ b/spec/neovim/session_spec.rb
@@ -99,7 +99,7 @@ module Neovim
       let!(:nvim_pid) do
         pid = Process.spawn(
           {"NVIM_LISTEN_ADDRESS" => "0.0.0.0:#{nvim_port}"},
-          "nvim --headless -n -u NONE",
+          "nvim --headless -i NONE -u NONE -n",
           [:out, :err] => "/dev/null"
         )
 
@@ -126,7 +126,7 @@ module Neovim
       let!(:nvim_pid) do
         pid = Process.spawn(
           {"NVIM_LISTEN_ADDRESS" => socket_path},
-          "nvim --headless -n -u NONE",
+          "nvim --headless -i NONE -u NONE -n",
           [:out, :err] => "/dev/null"
         )
 
@@ -149,7 +149,7 @@ module Neovim
     end
 
     context "child" do
-      let!(:session) { Session.child(["nvim", "-n", "-u", "NONE"]) }
+      let!(:session) { Session.child(["nvim", "-i", "NONE", "-u", "NONE", "-n"]) }
       include_context "session behavior"
       after { session.shutdown }
     end

--- a/spec/neovim/session_spec.rb
+++ b/spec/neovim/session_spec.rb
@@ -99,7 +99,7 @@ module Neovim
       let!(:nvim_pid) do
         pid = Process.spawn(
           {"NVIM_LISTEN_ADDRESS" => "0.0.0.0:#{nvim_port}"},
-          "nvim --headless -i NONE -u NONE -n",
+          "#{Support.child_argv.join(" ")} --headless",
           [:out, :err] => "/dev/null"
         )
 
@@ -126,7 +126,7 @@ module Neovim
       let!(:nvim_pid) do
         pid = Process.spawn(
           {"NVIM_LISTEN_ADDRESS" => socket_path},
-          "nvim --headless -i NONE -u NONE -n",
+          "#{Support.child_argv.join(" ")} --headless",
           [:out, :err] => "/dev/null"
         )
 
@@ -149,7 +149,7 @@ module Neovim
     end
 
     context "child" do
-      let!(:session) { Session.child(["nvim", "-i", "NONE", "-u", "NONE", "-n"]) }
+      let!(:session) { Session.child(Support.child_argv) }
       include_context "session behavior"
       after { session.shutdown }
     end

--- a/spec/neovim/window_spec.rb
+++ b/spec/neovim/window_spec.rb
@@ -2,7 +2,7 @@ require "helper"
 
 module Neovim
   RSpec.describe Window do
-    let(:client) { Neovim.attach_child(["nvim", "-i", "NONE", "-u", "NONE", "-n"]) }
+    let(:client) { Neovim.attach_child(Support.child_argv) }
     let(:window) { client.current.window }
     after { client.shutdown }
 

--- a/spec/neovim/window_spec.rb
+++ b/spec/neovim/window_spec.rb
@@ -2,7 +2,7 @@ require "helper"
 
 module Neovim
   RSpec.describe Window do
-    let(:client) { Neovim.attach_child(["nvim", "-n", "-u", "NONE"]) }
+    let(:client) { Neovim.attach_child(["nvim", "-i", "NONE", "-u", "NONE", "-n"]) }
     let(:window) { client.current.window }
     after { client.shutdown }
 

--- a/spec/neovim_spec.rb
+++ b/spec/neovim_spec.rb
@@ -1,7 +1,7 @@
 require "helper"
 
 RSpec.describe Neovim do
-  let(:nvim_argv) { %w(nvim --headless -i NONE -u NONE -n) }
+  let(:nvim_argv) { Support.child_argv }
 
   describe ".attach_tcp" do
     it "attaches to a TCP socket" do

--- a/spec/neovim_spec.rb
+++ b/spec/neovim_spec.rb
@@ -1,7 +1,7 @@
 require "helper"
 
 RSpec.describe Neovim do
-  let(:nvim_argv) { %w(nvim --headless -u NONE -i NONE -n) }
+  let(:nvim_argv) { %w(nvim --headless -i NONE -u NONE -n) }
 
   describe ".attach_tcp" do
     it "attaches to a TCP socket" do


### PR DESCRIPTION
This prevents the tests from altering the user's own shada history if
he/she runs the tests on a local install.

Fixes #16
