### PR TITLE
Make Window#cursor= behavior match Vim

### DIFF
--- a/lib/neovim/window.rb
+++ b/lib/neovim/window.rb
@@ -53,7 +53,8 @@ module Neovim
     # @param coords [Array(Fixnum, Fixnum)]
     # @return [Array(Fixnum, Fixnum)]
     def cursor=(coords)
-      set_cursor(coords)
+      x, y = coords
+      @session.request(:vim_eval, "cursor(#{x}, #{y + 1})")
     end
 
 # The following methods are dynamically generated.

--- a/spec/neovim/window_spec.rb
+++ b/spec/neovim/window_spec.rb
@@ -69,6 +69,18 @@ module Neovim
             client.command("normal ix")
           }.to change { client.current.line }.to("oxne")
         end
+
+        it "supports out of range indexes" do
+          window.buffer.lines = ["x", "xx"]
+
+          expect {
+            window.cursor = [10, 10]
+          }.to change { window.cursor }.to([2, 1])
+        end
+
+        it "returns the cursor array" do
+          expect(window.cursor = [10, 10]).to eq([10, 10])
+        end
       end
     end
   end


### PR DESCRIPTION
- Out of bounds cursor positions are acceptable
- Return cursor array

Addresses https://github.com/alexgenco/neovim-ruby/issues/19