### PR TITLE
Update API to use exclusively nvim_* functions

### DIFF
--- a/lib/neovim/buffer.rb
+++ b/lib/neovim/buffer.rb
@@ -6,12 +6,11 @@ module Neovim
   #
   # The methods documented here were generated using NVIM v0.2.0
   class Buffer < RemoteObject
-    # A +LineRange+ object representing the buffer's lines.
-    #
-    # @return [LineRange]
-    # @see LineRange
-    def lines
-      @lines ||= LineRange.new(self, 0, -1)
+    attr_reader :lines
+
+    def initialize(*args)
+      super
+      @lines = LineRange.new(self)
     end
 
     # Replace all the lines of the buffer.
@@ -19,7 +18,7 @@ module Neovim
     # @param strs [Array<String>] The replacement lines
     # @return [Array<String>]
     def lines=(strs)
-      lines[0..-1] = strs
+      @lines[0..-1] = strs
     end
 
     # Get the buffer name.
@@ -55,7 +54,7 @@ module Neovim
     # @param index [Integer]
     # @return [String]
     def [](index)
-      lines[index-1]
+      @lines[index-1]
     end
 
     # Set the given line (1-indexed).
@@ -64,7 +63,7 @@ module Neovim
     # @param str [String]
     # @return [String]
     def []=(index, str)
-      lines[index-1] = str
+      @lines[index-1] = str
     end
 
     # Delete the given line (1-indexed).
@@ -72,7 +71,8 @@ module Neovim
     # @param index [Integer]
     # @return [void]
     def delete(index)
-      lines.delete(index-1)
+      @lines.delete(index-1)
+      nil
     end
 
     # Append a line after the given line (1-indexed).
@@ -84,7 +84,7 @@ module Neovim
     # @param str [String]
     # @return [String]
     def append(index, str)
-      window = @session.request(:vim_get_current_window)
+      window = @session.request(:nvim_get_current_win)
       cursor = window.cursor
 
       if index < 0
@@ -101,7 +101,7 @@ module Neovim
     # @return [String, nil]
     def line
       if active?
-        @session.request(:vim_get_current_line)
+        @session.request(:nvim_get_current_line)
       end
     end
 
@@ -111,7 +111,7 @@ module Neovim
     # @return [String, nil]
     def line=(str)
       if active?
-        @session.request(:vim_set_current_line, str)
+        @session.request(:nvim_set_current_line, str)
       end
     end
 
@@ -120,8 +120,7 @@ module Neovim
     # @return [Integer, nil]
     def line_number
       if active?
-        window = @session.request(:vim_get_current_window)
-        @session.request(:window_get_cursor, window)[0]
+        @session.request(:nvim_get_current_win).get_cursor[0]
       end
     end
 

--- a/lib/neovim/buffer.rb
+++ b/lib/neovim/buffer.rb
@@ -22,24 +22,6 @@ module Neovim
       lines[0..-1] = strs
     end
 
-    # A +LineRange+ object representing the buffer's selection range.
-    #
-    # @return [LineRange]
-    # @see LineRange
-    def range
-      @range ||= LineRange.new(self, 0, -1)
-    end
-
-    # Set the buffer's current selection range.
-    #
-    # @param _range [Range] The replacement range
-    # @return [LineRange]
-    # @see LineRange
-    def range=(_range)
-      _end = _range.exclude_end? ? _range.end - 1 : _range.end
-      @range = LineRange.new(self, _range.begin, _end)
-    end
-
     # Get the buffer name.
     #
     # @return [String]

--- a/lib/neovim/buffer.rb
+++ b/lib/neovim/buffer.rb
@@ -128,120 +128,100 @@ module Neovim
     #
     # @return [Boolean]
     def active?
-      @session.request(:vim_get_current_buffer) == self
+      @session.request(:nvim_get_current_buf) == self
     end
 
 # The following methods are dynamically generated.
 =begin
-@method get_line(index)
-  Send the +buffer_get_line+ RPC to +nvim+
-  @param [Integer] index
-  @return [String]
-
-@method set_line(index, line)
-  Send the +buffer_set_line+ RPC to +nvim+
-  @param [Integer] index
-  @param [String] line
-  @return [void]
-
-@method del_line(index)
-  Send the +buffer_del_line+ RPC to +nvim+
-  @param [Integer] index
-  @return [void]
-
-@method get_line_slice(start, end, include_start, include_end)
-  Send the +buffer_get_line_slice+ RPC to +nvim+
-  @param [Integer] start
-  @param [Integer] end
-  @param [Boolean] include_start
-  @param [Boolean] include_end
-  @return [Array<String>]
-
-@method set_line_slice(start, end, include_start, include_end, replacement)
-  Send the +buffer_set_line_slice+ RPC to +nvim+
-  @param [Integer] start
-  @param [Integer] end
-  @param [Boolean] include_start
-  @param [Boolean] include_end
-  @param [Array<String>] replacement
-  @return [void]
-
-@method set_var(name, value)
-  Send the +buffer_set_var+ RPC to +nvim+
-  @param [String] name
-  @param [Object] value
-  @return [Object]
-
-@method del_var(name)
-  Send the +buffer_del_var+ RPC to +nvim+
-  @param [String] name
-  @return [Object]
-
-@method insert(lnum, lines)
-  Send the +buffer_insert+ RPC to +nvim+
-  @param [Integer] lnum
-  @param [Array<String>] lines
-  @return [void]
-
-@method line_count
-  Send the +buffer_line_count+ RPC to +nvim+
+@method line_count(buffer)
+  See +:h nvim_buf_line_count()+
+  @param [Buffer] buffer
   @return [Integer]
 
-@method get_lines(start, end, strict_indexing)
-  Send the +buffer_get_lines+ RPC to +nvim+
+@method get_lines(buffer, start, end, strict_indexing)
+  See +:h nvim_buf_get_lines()+
+  @param [Buffer] buffer
   @param [Integer] start
   @param [Integer] end
   @param [Boolean] strict_indexing
   @return [Array<String>]
 
-@method set_lines(start, end, strict_indexing, replacement)
-  Send the +buffer_set_lines+ RPC to +nvim+
+@method set_lines(buffer, start, end, strict_indexing, replacement)
+  See +:h nvim_buf_set_lines()+
+  @param [Buffer] buffer
   @param [Integer] start
   @param [Integer] end
   @param [Boolean] strict_indexing
   @param [Array<String>] replacement
   @return [void]
 
-@method get_var(name)
-  Send the +buffer_get_var+ RPC to +nvim+
+@method get_var(buffer, name)
+  See +:h nvim_buf_get_var()+
+  @param [Buffer] buffer
   @param [String] name
   @return [Object]
 
-@method get_option(name)
-  Send the +buffer_get_option+ RPC to +nvim+
-  @param [String] name
-  @return [Object]
+@method get_changedtick(buffer)
+  See +:h nvim_buf_get_changedtick()+
+  @param [Buffer] buffer
+  @return [Integer]
 
-@method set_option(name, value)
-  Send the +buffer_set_option+ RPC to +nvim+
+@method set_var(buffer, name, value)
+  See +:h nvim_buf_set_var()+
+  @param [Buffer] buffer
   @param [String] name
   @param [Object] value
   @return [void]
 
-@method get_number
-  Send the +buffer_get_number+ RPC to +nvim+
-  @return [Integer]
-
-@method get_name
-  Send the +buffer_get_name+ RPC to +nvim+
-  @return [String]
-
-@method set_name(name)
-  Send the +buffer_set_name+ RPC to +nvim+
+@method del_var(buffer, name)
+  See +:h nvim_buf_del_var()+
+  @param [Buffer] buffer
   @param [String] name
   @return [void]
 
-@method is_valid
-  Send the +buffer_is_valid+ RPC to +nvim+
+@method get_option(buffer, name)
+  See +:h nvim_buf_get_option()+
+  @param [Buffer] buffer
+  @param [String] name
+  @return [Object]
+
+@method set_option(buffer, name, value)
+  See +:h nvim_buf_set_option()+
+  @param [Buffer] buffer
+  @param [String] name
+  @param [Object] value
+  @return [void]
+
+@method get_number(buffer)
+  See +:h nvim_buf_get_number()+
+  @param [Buffer] buffer
+  @return [Integer]
+
+@method get_name(buffer)
+  See +:h nvim_buf_get_name()+
+  @param [Buffer] buffer
+  @return [String]
+
+@method set_name(buffer, name)
+  See +:h nvim_buf_set_name()+
+  @param [Buffer] buffer
+  @param [String] name
+  @return [void]
+
+@method is_valid(buffer)
+  See +:h nvim_buf_is_valid()+
+  @param [Buffer] buffer
   @return [Boolean]
 
-@method get_mark(name)
-  Send the +buffer_get_mark+ RPC to +nvim+
+@method get_mark(buffer, name)
+  See +:h nvim_buf_get_mark()+
+  @param [Buffer] buffer
   @param [String] name
   @return [Array<Integer>]
 
-@method add_highlight(src_id, hl_group, line, col_start, col_end)
-  Send the +buffer_add_highlight+ RPC to +nvim+
+@method add_highlight(buffer, src_id, hl_group, line, col_start, col_end)
+  See +:h nvim_buf_add_highlight()+
+  @param [Buffer] buffer
   @param [Integer] src_id
   @param [String] hl_group
   @param [Integer] line
@@ -249,8 +229,9 @@ module Neovim
   @param [Integer] col_end
   @return [Integer]
 
-@method clear_highlight(src_id, line_start, line_end)
-  Send the +buffer_clear_highlight+ RPC to +nvim+
+@method clear_highlight(buffer, src_id, line_start, line_end)
+  See +:h nvim_buf_clear_highlight()+
+  @param [Buffer] buffer
   @param [Integer] src_id
   @param [Integer] line_start
   @param [Integer] line_end

--- a/lib/neovim/client.rb
+++ b/lib/neovim/client.rb
@@ -98,184 +98,186 @@ module Neovim
     private
 
     def rpc_methods
-      @api.functions_with_prefix("vim_").map do |func|
-        func.name.sub(/\Avim_/, "").to_sym
-      end
+      @api.functions_for_object(self).map(&:method_name)
     end
 
     public
 
 # The following methods are dynamically generated.
 =begin
-@method set_var(name, value)
-  Send the +vim_set_var+ RPC to +nvim+
-  @param [String] name
-  @param [Object] value
-  @return [Object]
-
-@method del_var(name)
-  Send the +vim_del_var+ RPC to +nvim+
-  @param [String] name
-  @return [Object]
-
-@method command(command)
-  Send the +vim_command+ RPC to +nvim+
-  @param [String] command
+@method ui_attach(height, options)
+  See +:h nvim_ui_attach()+
+  @param [Integer] height
+  @param [Hash] options
   @return [void]
 
-@method feedkeys(keys, mode, escape_csi)
-  Send the +vim_feedkeys+ RPC to +nvim+
-  @param [String] keys
+@method ui_detach
+  See +:h nvim_ui_detach()+
+  @return [void]
+
+@method ui_try_resize(height)
+  See +:h nvim_ui_try_resize()+
+  @param [Integer] height
+  @return [void]
+
+@method ui_set_option(value)
+  See +:h nvim_ui_set_option()+
+  @param [Object] value
+  @return [void]
+
+@method command
+  See +:h nvim_command()+
+  @return [void]
+
+@method feedkeys(mode, escape_csi)
+  See +:h nvim_feedkeys()+
   @param [String] mode
   @param [Boolean] escape_csi
   @return [void]
 
-@method input(keys)
-  Send the +vim_input+ RPC to +nvim+
-  @param [String] keys
+@method input
+  See +:h nvim_input()+
   @return [Integer]
 
-@method replace_termcodes(str, from_part, do_lt, special)
-  Send the +vim_replace_termcodes+ RPC to +nvim+
-  @param [String] str
+@method replace_termcodes(from_part, do_lt, special)
+  See +:h nvim_replace_termcodes()+
   @param [Boolean] from_part
   @param [Boolean] do_lt
   @param [Boolean] special
   @return [String]
 
-@method command_output(str)
-  Send the +vim_command_output+ RPC to +nvim+
-  @param [String] str
+@method command_output
+  See +:h nvim_command_output()+
   @return [String]
 
-@method eval(expr)
-  Send the +vim_eval+ RPC to +nvim+
-  @param [String] expr
+@method eval
+  See +:h nvim_eval()+
   @return [Object]
 
-@method call_function(fname, args)
-  Send the +vim_call_function+ RPC to +nvim+
-  @param [String] fname
+@method call_function(args)
+  See +:h nvim_call_function()+
   @param [Array] args
   @return [Object]
 
-@method strwidth(str)
-  Send the +vim_strwidth+ RPC to +nvim+
-  @param [String] str
+@method strwidth
+  See +:h nvim_strwidth()+
   @return [Integer]
 
 @method list_runtime_paths
-  Send the +vim_list_runtime_paths+ RPC to +nvim+
+  See +:h nvim_list_runtime_paths()+
   @return [Array<String>]
 
-@method change_directory(dir)
-  Send the +vim_change_directory+ RPC to +nvim+
-  @param [String] dir
+@method set_current_dir
+  See +:h nvim_set_current_dir()+
   @return [void]
 
 @method get_current_line
-  Send the +vim_get_current_line+ RPC to +nvim+
+  See +:h nvim_get_current_line()+
   @return [String]
 
-@method set_current_line(line)
-  Send the +vim_set_current_line+ RPC to +nvim+
-  @param [String] line
+@method set_current_line
+  See +:h nvim_set_current_line()+
   @return [void]
 
 @method del_current_line
-  Send the +vim_del_current_line+ RPC to +nvim+
+  See +:h nvim_del_current_line()+
   @return [void]
 
-@method get_var(name)
-  Send the +vim_get_var+ RPC to +nvim+
-  @param [String] name
+@method get_var
+  See +:h nvim_get_var()+
   @return [Object]
 
-@method get_vvar(name)
-  Send the +vim_get_vvar+ RPC to +nvim+
-  @param [String] name
+@method set_var(value)
+  See +:h nvim_set_var()+
+  @param [Object] value
+  @return [void]
+
+@method del_var
+  See +:h nvim_del_var()+
+  @return [void]
+
+@method get_vvar
+  See +:h nvim_get_vvar()+
   @return [Object]
 
-@method get_option(name)
-  Send the +vim_get_option+ RPC to +nvim+
-  @param [String] name
+@method get_option
+  See +:h nvim_get_option()+
   @return [Object]
 
-@method out_write(str)
-  Send the +vim_out_write+ RPC to +nvim+
-  @param [String] str
+@method out_write
+  See +:h nvim_out_write()+
   @return [void]
 
-@method err_write(str)
-  Send the +vim_err_write+ RPC to +nvim+
-  @param [String] str
+@method err_write
+  See +:h nvim_err_write()+
   @return [void]
 
-@method report_error(str)
-  Send the +vim_report_error+ RPC to +nvim+
-  @param [String] str
+@method err_writeln
+  See +:h nvim_err_writeln()+
   @return [void]
 
-@method get_buffers
-  Send the +vim_get_buffers+ RPC to +nvim+
+@method list_bufs
+  See +:h nvim_list_bufs()+
   @return [Array<Buffer>]
 
-@method get_current_buffer
-  Send the +vim_get_current_buffer+ RPC to +nvim+
+@method get_current_buf
+  See +:h nvim_get_current_buf()+
   @return [Buffer]
 
-@method set_current_buffer(buffer)
-  Send the +vim_set_current_buffer+ RPC to +nvim+
-  @param [Buffer] buffer
+@method set_current_buf
+  See +:h nvim_set_current_buf()+
   @return [void]
 
-@method get_windows
-  Send the +vim_get_windows+ RPC to +nvim+
+@method list_wins
+  See +:h nvim_list_wins()+
   @return [Array<Window>]
 
-@method get_current_window
-  Send the +vim_get_current_window+ RPC to +nvim+
+@method get_current_win
+  See +:h nvim_get_current_win()+
   @return [Window]
 
-@method set_current_window(window)
-  Send the +vim_set_current_window+ RPC to +nvim+
-  @param [Window] window
+@method set_current_win
+  See +:h nvim_set_current_win()+
   @return [void]
 
-@method get_tabpages
-  Send the +vim_get_tabpages+ RPC to +nvim+
+@method list_tabpages
+  See +:h nvim_list_tabpages()+
   @return [Array<Tabpage>]
 
 @method get_current_tabpage
-  Send the +vim_get_current_tabpage+ RPC to +nvim+
+  See +:h nvim_get_current_tabpage()+
   @return [Tabpage]
 
-@method set_current_tabpage(tabpage)
-  Send the +vim_set_current_tabpage+ RPC to +nvim+
-  @param [Tabpage] tabpage
+@method set_current_tabpage
+  See +:h nvim_set_current_tabpage()+
   @return [void]
 
-@method subscribe(event)
-  Send the +vim_subscribe+ RPC to +nvim+
-  @param [String] event
+@method subscribe
+  See +:h nvim_subscribe()+
   @return [void]
 
-@method unsubscribe(event)
-  Send the +vim_unsubscribe+ RPC to +nvim+
-  @param [String] event
+@method unsubscribe
+  See +:h nvim_unsubscribe()+
   @return [void]
 
-@method name_to_color(name)
-  Send the +vim_name_to_color+ RPC to +nvim+
-  @param [String] name
+@method get_color_by_name
+  See +:h nvim_get_color_by_name()+
   @return [Integer]
 
 @method get_color_map
-  Send the +vim_get_color_map+ RPC to +nvim+
-  @return [Dictionary]
+  See +:h nvim_get_color_map()+
+  @return [Hash]
+
+@method get_mode
+  See +:h nvim_get_mode()+
+  @return [Hash]
 
 @method get_api_info
-  Send the +vim_get_api_info+ RPC to +nvim+
+  See +:h nvim_get_api_info()+
+  @return [Array]
+
+@method call_atomic
+  See +:h nvim_call_atomic()+
   @return [Array]
 
 =end

--- a/lib/neovim/client.rb
+++ b/lib/neovim/client.rb
@@ -2,7 +2,7 @@ require "neovim/current"
 
 module Neovim
   # Client to a running +nvim+ instance. The interface is generated at
-  # runtime via the +vim_get_api_info+ RPC call. Some methods return
+  # runtime via the +nvim_get_api_info+ RPC call. Some methods return
   # +RemoteObject+ subclasses (i.e. +Buffer+, +Window+, or +Tabpage+),
   # which similarly have dynamically generated interfaces.
   #
@@ -24,7 +24,7 @@ module Neovim
 
     # Intercept method calls and delegate to appropriate RPC methods.
     def method_missing(method_name, *args)
-      if func = @api.function("vim_#{method_name}")
+      if func = @api.function_for_object_method(self, method_name)
         func.call(@session, *args)
       else
         super
@@ -53,14 +53,14 @@ module Neovim
       @current ||= Current.new(@session)
     end
 
-    # Evaluate the VimL expression (alias for +vim_eval+).
+    # Evaluate the VimL expression (alias for +nvim_eval+).
     #
     # @param expr [String] A VimL expression.
     # @return [Object]
     # @example Return a list from VimL
     #   client.evaluate('[1, 2]') # => [1, 2]
     def evaluate(expr)
-      @api.function(:vim_eval).call(@session, expr)
+      @api.function_for_object_method(self, :eval).call(@session, expr)
     end
 
     # Display a message.
@@ -85,9 +85,9 @@ module Neovim
     #   client.set_option("timeoutlen=0")
     def set_option(*args)
       if args.size > 1
-        @api.function("vim_set_option").call(@session, *args)
+        @api.function_for_object_method(self, :set_option).call(@session, *args)
       else
-        @api.function("vim_command").call(@session, "set #{args.first}")
+        @api.function_for_object_method(self, :command).call(@session, "set #{args.first}")
       end
     end
 

--- a/lib/neovim/current.rb
+++ b/lib/neovim/current.rb
@@ -15,7 +15,7 @@ module Neovim
     #
     # @return [String]
     def line
-      @session.request(:vim_get_current_line)
+      @session.request(:nvim_get_current_line)
     end
 
     # Set the line under the cursor.
@@ -23,14 +23,14 @@ module Neovim
     # @param line [String] The target line contents.
     # @return [String]
     def line=(line)
-      @session.request(:vim_set_current_line, line)
+      @session.request(:nvim_set_current_line, line)
     end
 
     # Get the active buffer.
     #
     # @return [Buffer]
     def buffer
-      @session.request(:vim_get_current_buffer)
+      @session.request(:nvim_get_current_buf)
     end
 
     # Set the active buffer.
@@ -38,14 +38,14 @@ module Neovim
     # @param buffer [Buffer, Integer] The target buffer or index.
     # @return [Buffer, Integer]
     def buffer=(buffer)
-      @session.request(:vim_set_current_buffer, buffer)
+      @session.request(:nvim_set_current_buf, buffer)
     end
 
     # Get the active window.
     #
     # @return [Window]
     def window
-      @session.request(:vim_get_current_window)
+      @session.request(:nvim_get_current_win)
     end
 
     # Set the active window.
@@ -53,14 +53,14 @@ module Neovim
     # @param window [Window, Integer] The target window or index.
     # @return [Window, Integer]
     def window=(window)
-      @session.request(:vim_set_current_window, window)
+      @session.request(:nvim_set_current_win, window)
     end
 
     # Get the active tabpage.
     #
     # @return [Tabpage]
     def tabpage
-      @session.request(:vim_get_current_tabpage)
+      @session.request(:nvim_get_current_tabpage)
     end
 
     # Set the active tabpage.
@@ -68,7 +68,7 @@ module Neovim
     # @param tabpage [Tabpage, Integer] The target tabpage or index.
     # @return [Tabpage, Integer]
     def tabpage=(tabpage)
-      @session.request(:vim_set_current_tabpage, tabpage)
+      @session.request(:nvim_set_current_tabpage, tabpage)
     end
   end
 end

--- a/lib/neovim/current.rb
+++ b/lib/neovim/current.rb
@@ -9,7 +9,6 @@ module Neovim
   class Current
     def initialize(session)
       @session = session
-      @range = (0..-1)
     end
 
     # Get the line under the cursor.
@@ -31,9 +30,7 @@ module Neovim
     #
     # @return [Buffer]
     def buffer
-      @session.request(:vim_get_current_buffer).tap do |buf|
-        buf.range = @range
-      end
+      @session.request(:vim_get_current_buffer)
     end
 
     # Set the active buffer.
@@ -72,13 +69,6 @@ module Neovim
     # @return [Tabpage, Integer]
     def tabpage=(tabpage)
       @session.request(:vim_set_current_tabpage, tabpage)
-    end
-
-    # Set the current line range of the current buffer.
-    #
-    # @param range [Range] The target range
-    def range=(range)
-      @range = range
     end
   end
 end

--- a/lib/neovim/remote_object.rb
+++ b/lib/neovim/remote_object.rb
@@ -23,7 +23,7 @@ module Neovim
 
     # Intercept method calls and delegate to appropriate RPC methods.
     def method_missing(method_name, *args)
-      if func = @api.function(qualify(method_name))
+      if func = @api.function_for_object_method(self, method_name)
         func.call(@session, @index, *args)
       else
         super
@@ -48,17 +48,7 @@ module Neovim
     private
 
     def rpc_methods
-      @api.functions_with_prefix(function_prefix).map do |func|
-        func.name.sub(/\A#{function_prefix}/, "").to_sym
-      end
-    end
-
-    def function_prefix
-      "#{self.class.to_s.split("::").last.downcase}_"
-    end
-
-    def qualify(method_name)
-      :"#{function_prefix}#{method_name}"
+      @api.functions_for_object(self).map(&:method_name)
     end
   end
 end

--- a/lib/neovim/ruby_provider.rb
+++ b/lib/neovim/ruby_provider.rb
@@ -32,7 +32,7 @@ module Neovim
         end
 
         $stderr.define_singleton_method(:write) do |string|
-          client.report_error(string)
+          client.err_writeln(string)
         end
 
         begin
@@ -81,7 +81,7 @@ module Neovim
       __plug.__send__(:rpc, :ruby_do_range) do |__nvim, *__args|
         __wrap_client(__nvim) do
           __start, __stop, __ruby = __args
-          __buffer = __nvim.get_current_buffer
+          __buffer = __nvim.get_current_buf
 
           __update_lines_in_chunks(__buffer, __start, __stop, 5000) do |__lines|
             __lines.map do |__line|
@@ -118,7 +118,7 @@ module Neovim
         yield
       rescue SyntaxError, LoadError, StandardError => e
         msg = [e.class, e.message].join(": ")
-        client.report_error(msg.lines.first.strip)
+        client.err_writeln(msg.lines.first.strip)
       end
     end
 

--- a/lib/neovim/ruby_provider/buffer_ext.rb
+++ b/lib/neovim/ruby_provider/buffer_ext.rb
@@ -3,15 +3,15 @@ require "neovim/ruby_provider/vim"
 module Neovim
   class Buffer
     def self.current
-      ::Vim.get_current_buffer
+      ::Vim.get_current_buf
     end
 
     def self.count
-      ::Vim.get_buffers.size
+      ::Vim.list_bufs.size
     end
 
     def self.[](index)
-      ::Vim.get_buffers[index]
+      ::Vim.list_bufs[index]
     end
   end
 end

--- a/lib/neovim/ruby_provider/vim.rb
+++ b/lib/neovim/ruby_provider/vim.rb
@@ -24,10 +24,10 @@ module Vim
     bufnr = client.evaluate("bufnr('%')")
 
     $curbuf = @__buffer_cache.fetch(bufnr) do
-      @__buffer_cache[bufnr] = client.get_current_buffer
+      @__buffer_cache[bufnr] = client.get_current_buf
     end
 
-    $curwin = client.get_current_window
+    $curwin = client.get_current_win
   end
 end
 

--- a/lib/neovim/ruby_provider/window_ext.rb
+++ b/lib/neovim/ruby_provider/window_ext.rb
@@ -3,15 +3,15 @@ require "neovim/ruby_provider/vim"
 module Neovim
   class Window
     def self.current
-      ::Vim.get_current_window
+      ::Vim.get_current_win
     end
 
     def self.count
-      ::Vim.get_current_tabpage.get_windows.size
+      ::Vim.get_current_tabpage.list_wins.size
     end
 
     def self.[](index)
-      ::Vim.get_current_tabpage.get_windows[index]
+      ::Vim.get_current_tabpage.list_wins[index]
     end
   end
 end

--- a/lib/neovim/session.rb
+++ b/lib/neovim/session.rb
@@ -48,16 +48,16 @@ module Neovim
       @running = false
     end
 
-    # Return the +nvim+ API as described in the +vim_get_api_info+ call.
+    # Return the +nvim+ API as described in the +nvim_get_api_info+ call.
     # Defaults to empty API information.
     def api
       @api ||= API.null
     end
 
-    # Discover the +nvim+ API as described in the +vim_get_api_info+ call,
+    # Discover the +nvim+ API as described in the +nvim_get_api_info+ call,
     # propagating it down to lower layers of the stack.
     def discover_api
-      @api = API.new(request(:vim_get_api_info)).tap do |api|
+      @api = API.new(request(:nvim_get_api_info)).tap do |api|
         @rpc.serializer.register_types(api, self)
       end
     end
@@ -111,7 +111,7 @@ module Neovim
       end
     end
 
-    # Return the channel ID if registered via +vim_get_api_info+.
+    # Return the channel ID if registered via +nvim_get_api_info+.
     def channel_id
       api.channel_id
     end

--- a/lib/neovim/tabpage.rb
+++ b/lib/neovim/tabpage.rb
@@ -5,35 +5,45 @@ module Neovim
   #
   # The methods documented here were generated using NVIM v0.2.0
   class Tabpage < RemoteObject
-
 # The following methods are dynamically generated.
 =begin
-@method set_var(name, value)
-  Send the +tabpage_set_var+ RPC to +nvim+
-  @param [String] name
-  @param [Object] value
-  @return [Object]
-
-@method del_var(name)
-  Send the +tabpage_del_var+ RPC to +nvim+
-  @param [String] name
-  @return [Object]
-
-@method get_windows
-  Send the +tabpage_get_windows+ RPC to +nvim+
+@method list_wins(tabpage)
+  See +:h nvim_tabpage_list_wins()+
+  @param [Tabpage] tabpage
   @return [Array<Window>]
 
-@method get_var(name)
-  Send the +tabpage_get_var+ RPC to +nvim+
+@method get_var(tabpage, name)
+  See +:h nvim_tabpage_get_var()+
+  @param [Tabpage] tabpage
   @param [String] name
   @return [Object]
 
-@method get_window
-  Send the +tabpage_get_window+ RPC to +nvim+
+@method set_var(tabpage, name, value)
+  See +:h nvim_tabpage_set_var()+
+  @param [Tabpage] tabpage
+  @param [String] name
+  @param [Object] value
+  @return [void]
+
+@method del_var(tabpage, name)
+  See +:h nvim_tabpage_del_var()+
+  @param [Tabpage] tabpage
+  @param [String] name
+  @return [void]
+
+@method get_win(tabpage)
+  See +:h nvim_tabpage_get_win()+
+  @param [Tabpage] tabpage
   @return [Window]
 
-@method is_valid
-  Send the +tabpage_is_valid+ RPC to +nvim+
+@method get_number(tabpage)
+  See +:h nvim_tabpage_get_number()+
+  @param [Tabpage] tabpage
+  @return [Integer]
+
+@method is_valid(tabpage)
+  See +:h nvim_tabpage_is_valid()+
+  @param [Tabpage] tabpage
   @return [Boolean]
 
 =end

--- a/lib/neovim/window.rb
+++ b/lib/neovim/window.rb
@@ -59,79 +59,99 @@ module Neovim
       _x, _y = coords
       x = [_x, 1].max
       y = [_y, 0].max + 1
-      @session.request(:vim_eval, "cursor(#{x}, #{y})")
+      @session.request(:nvim_eval, "cursor(#{x}, #{y})")
     end
 
 # The following methods are dynamically generated.
 =begin
-@method set_var(name, value)
-  Send the +window_set_var+ RPC to +nvim+
-  @param [String] name
-  @param [Object] value
-  @return [Object]
-
-@method del_var(name)
-  Send the +window_del_var+ RPC to +nvim+
-  @param [String] name
-  @return [Object]
-
-@method get_buffer
-  Send the +window_get_buffer+ RPC to +nvim+
+@method get_buf(window)
+  See +:h nvim_win_get_buf()+
+  @param [Window] window
   @return [Buffer]
 
-@method get_cursor
-  Send the +window_get_cursor+ RPC to +nvim+
+@method get_cursor(window)
+  See +:h nvim_win_get_cursor()+
+  @param [Window] window
   @return [Array<Integer>]
 
-@method set_cursor(pos)
-  Send the +window_set_cursor+ RPC to +nvim+
+@method set_cursor(window, pos)
+  See +:h nvim_win_set_cursor()+
+  @param [Window] window
   @param [Array<Integer>] pos
   @return [void]
 
-@method get_height
-  Send the +window_get_height+ RPC to +nvim+
+@method get_height(window)
+  See +:h nvim_win_get_height()+
+  @param [Window] window
   @return [Integer]
 
-@method set_height(height)
-  Send the +window_set_height+ RPC to +nvim+
+@method set_height(window, height)
+  See +:h nvim_win_set_height()+
+  @param [Window] window
   @param [Integer] height
   @return [void]
 
-@method get_width
-  Send the +window_get_width+ RPC to +nvim+
+@method get_width(window)
+  See +:h nvim_win_get_width()+
+  @param [Window] window
   @return [Integer]
 
-@method set_width(width)
-  Send the +window_set_width+ RPC to +nvim+
+@method set_width(window, width)
+  See +:h nvim_win_set_width()+
+  @param [Window] window
   @param [Integer] width
   @return [void]
 
-@method get_var(name)
-  Send the +window_get_var+ RPC to +nvim+
+@method get_var(window, name)
+  See +:h nvim_win_get_var()+
+  @param [Window] window
   @param [String] name
   @return [Object]
 
-@method get_option(name)
-  Send the +window_get_option+ RPC to +nvim+
-  @param [String] name
-  @return [Object]
-
-@method set_option(name, value)
-  Send the +window_set_option+ RPC to +nvim+
+@method set_var(window, name, value)
+  See +:h nvim_win_set_var()+
+  @param [Window] window
   @param [String] name
   @param [Object] value
   @return [void]
 
-@method get_position
-  Send the +window_get_position+ RPC to +nvim+
+@method del_var(window, name)
+  See +:h nvim_win_del_var()+
+  @param [Window] window
+  @param [String] name
+  @return [void]
+
+@method get_option(window, name)
+  See +:h nvim_win_get_option()+
+  @param [Window] window
+  @param [String] name
+  @return [Object]
+
+@method set_option(window, name, value)
+  See +:h nvim_win_set_option()+
+  @param [Window] window
+  @param [String] name
+  @param [Object] value
+  @return [void]
+
+@method get_position(window)
+  See +:h nvim_win_get_position()+
+  @param [Window] window
   @return [Array<Integer>]
 
-@method get_tabpage
-  Send the +window_get_tabpage+ RPC to +nvim+
+@method get_tabpage(window)
+  See +:h nvim_win_get_tabpage()+
+  @param [Window] window
   @return [Tabpage]
 
-@method is_valid
-  Send the +window_is_valid+ RPC to +nvim+
+@method get_number(window)
+  See +:h nvim_win_get_number()+
+  @param [Window] window
+  @return [Integer]
+
+@method is_valid(window)
+  See +:h nvim_win_is_valid()+
+  @param [Window] window
   @return [Boolean]
 
 =end

--- a/lib/neovim/window.rb
+++ b/lib/neovim/window.rb
@@ -9,7 +9,7 @@ module Neovim
     #
     # @return [Buffer]
     def buffer
-      get_buffer
+      get_buf
     end
 
     # Get the height of the window

--- a/script/dump_api
+++ b/script/dump_api
@@ -7,4 +7,4 @@ require "pp"
 
 nvim_exe = ENV.fetch("NVIM_EXECUTABLE", "nvim")
 session = Neovim::Session.child([nvim_exe, "-u", "NONE", "-n"])
-pp session.request(:vim_get_api_info)
+pp session.request(:nvim_get_api_info)

--- a/script/generate_docs
+++ b/script/generate_docs
@@ -55,6 +55,7 @@ session.request(:nvim_get_api_info)[1]["functions"].each do |func|
   return_doc = "  @return [#{return_type}]\n"
   method_doc = [method_decl, method_desc, *param_docs, return_doc].join("\n")
   method_doc.gsub!(/ArrayOf\((\w+)[^)]*\)/, 'Array<\1>')
+  method_doc.gsub!(/Dictionary/, "Hash")
 
   case func_name
   when /nvim_buf_(.+)/

--- a/script/generate_docs
+++ b/script/generate_docs
@@ -5,7 +5,7 @@ $:.unshift File.expand_path("../../lib", __FILE__)
 require "neovim"
 require "pathname"
 
-vim_docs = []
+nvim_docs = []
 buffer_docs = []
 window_docs = []
 tabpage_docs = []
@@ -13,32 +13,42 @@ nvim_exe = ENV.fetch("NVIM_EXECUTABLE", "nvim")
 nvim_vrs = %x(#{nvim_exe} --version).split("\n").first
 
 session = Neovim::Session.child([nvim_exe, "-u", "NONE", "-n"])
-vim_defs = Neovim::Client.instance_methods(false)
+nvim_defs = Neovim::Client.instance_methods(false)
 buffer_defs = Neovim::Buffer.instance_methods(false)
 tabpage_defs = Neovim::Tabpage.instance_methods(false)
 window_defs = Neovim::Window.instance_methods(false)
 
-session.request(:vim_get_api_info)[1]["functions"].each do |func|
-  prefix, method_name = func["name"].split("_", 2)
+def add_method(docs, defs, method_name)
+  return if defs.include?(method_name.to_s)
+end
 
-  case prefix
-  when "vim"
-    next if vim_defs.include?(method_name.to_sym)
-  when "buffer"
+session.request(:nvim_get_api_info)[1]["functions"].each do |func|
+  func_name = func["name"]
+  params = func["parameters"]
+
+  case func_name
+  when /^nvim_buf_(.+)/
+    method_name = $1
     next if buffer_defs.include?(method_name.to_sym)
-  when "tabpage"
-    next if tabpage_defs.include?(method_name.to_sym)
-  when "window"
+  when /^nvim_win_(.+)/
+    method_name = $1
     next if window_defs.include?(method_name.to_sym)
+  when /^nvim_tabpage_(.+)/
+    method_name = $1
+    next if tabpage_defs.include?(method_name.to_sym)
+  when /^nvim_(.+)/
+    method_name = $1
+    params.shift
+    next if nvim_defs.include?(method_name.to_sym)
+  else
+    next
   end
 
   return_type = func["return_type"]
-  params = func["parameters"]
-  params.shift unless prefix == "vim"
   param_names = params.map(&:last)
   param_str = params.empty? ? "" : "(#{param_names.join(", ")})"
   method_decl = "@method #{method_name}#{param_str}"
-  method_desc = "  Send the +#{prefix}_#{method_name}+ RPC to +nvim+"
+  method_desc = "  See +:h #{func_name}()+"
   param_docs = params.map do |type, name|
     "  @param [#{type}] #{name}"
   end
@@ -46,21 +56,23 @@ session.request(:vim_get_api_info)[1]["functions"].each do |func|
   method_doc = [method_decl, method_desc, *param_docs, return_doc].join("\n")
   method_doc.gsub!(/ArrayOf\((\w+)[^)]*\)/, 'Array<\1>')
 
-  case prefix
-  when "vim"
-    vim_docs << method_doc
-  when "buffer"
+  case func_name
+  when /nvim_buf_(.+)/
     buffer_docs << method_doc
-  when "tabpage"
-    tabpage_docs << method_doc
-  when "window"
+  when /nvim_win_(.+)/
     window_docs << method_doc
+  when /nvim_tabpage_(.+)/
+    tabpage_docs << method_doc
+  when /nvim_(.+)/
+    nvim_docs << method_doc
+  else
+    raise "Unexpected function #{func_name.inspect}"
   end
 end
 
 lib_dir = Pathname.new(File.expand_path("../../lib/neovim", __FILE__))
 {
-  "client.rb" => vim_docs,
+  "client.rb" => nvim_docs,
   "buffer.rb" => buffer_docs,
   "tabpage.rb" => tabpage_docs,
   "window.rb" => window_docs,

--- a/spec/acceptance/runtime/rplugin/ruby/autocmds.rb
+++ b/spec/acceptance/runtime/rplugin/ruby/autocmds.rb
@@ -1,6 +1,6 @@
 Neovim.plugin do |plug|
   plug.autocmd(:BufEnter, :pattern => "*.rb") do |nvim|
-    nvim.get_current_buffer.set_var("rplugin_autocmd_BufEnter", true)
+    nvim.get_current_buf.set_var("rplugin_autocmd_BufEnter", true)
   end
 
   plug.autocmd(:BufEnter, :pattern => "*.c", :eval => "g:to_eval") do |nvim, to_eval|

--- a/spec/neovim/buffer_spec.rb
+++ b/spec/neovim/buffer_spec.rb
@@ -19,20 +19,6 @@ module Neovim
       end
     end
 
-    describe "#range" do
-      it "returns a LineRange" do
-        expect(buffer.range).to be_a(LineRange)
-      end
-    end
-
-    describe "#range=" do
-      it "updates the buffer's range" do
-        buffer.lines = ["one", "two", "three"]
-        buffer.range = (0..1)
-        expect(buffer.range.to_a).to eq(["one", "two"])
-      end
-    end
-
     describe "if_ruby compatibility" do
       describe "#name" do
         it "returns the buffer path as a string" do

--- a/spec/neovim/buffer_spec.rb
+++ b/spec/neovim/buffer_spec.rb
@@ -54,6 +54,16 @@ module Neovim
           buffer.lines = ["one", "two", "three"]
           expect(buffer[2]).to eq("two")
         end
+
+        it "raises an out of bounds exception" do
+          expect {
+            buffer[-5]
+          }.to raise_error(/out of bounds/)
+
+          expect {
+            buffer[10]
+          }.to raise_error(/out of bounds/)
+        end
       end
 
       describe "#[]=" do
@@ -71,6 +81,10 @@ module Neovim
 
         it "raises an out of bounds exception" do
           expect {
+            buffer[-5] = "line"
+          }.to raise_error(/out of bounds/)
+
+          expect {
             buffer[10] = "line"
           }.to raise_error(/out of bounds/)
         end
@@ -82,7 +96,21 @@ module Neovim
 
           expect {
             buffer.delete(1)
-          }.to change { buffer.lines }.to(["two"])
+          }.to change { buffer.lines.to_a }.to(["two"])
+        end
+
+        it "returns nil" do
+          expect(buffer.delete(1)).to eq(nil)
+        end
+
+        it "raises an out of bounds exception" do
+          expect {
+            buffer.delete(-5)
+          }.to raise_error(/out of bounds/)
+
+          expect {
+            buffer.delete(10)
+          }.to raise_error(/out of bounds/)
         end
       end
 
@@ -144,7 +172,7 @@ module Neovim
         it "sets the current line on an active buffer" do
           expect {
             buffer.line = "line"
-          }.to change { buffer.lines }.to(["line"])
+          }.to change { buffer.lines.to_a }.to(["line"])
         end
 
         it "has no effect when called on an inactive buffer" do

--- a/spec/neovim/client_spec.rb
+++ b/spec/neovim/client_spec.rb
@@ -26,7 +26,7 @@ module Neovim
     end
 
     describe "#method_missing" do
-      it "enables vim_* function calls" do
+      it "enables nvim_* function calls" do
         expect(client.strwidth("hi")).to eq(2)
       end
 
@@ -99,7 +99,7 @@ module Neovim
         it "runs the provided command" do
           expect {
             client.command("normal ix")
-          }.to change { client.current.buffer.lines }.to(["x"])
+          }.to change { client.current.buffer.lines.to_a }.to(["x"])
         end
       end
     end

--- a/spec/neovim/current_spec.rb
+++ b/spec/neovim/current_spec.rb
@@ -135,13 +135,5 @@ module Neovim
         expect(current.tabpage = tp0).to eq(tp0)
       end
     end
-
-    describe "#range=" do
-      it "sets the line range of the current buffer" do
-        current.buffer.lines = ["one", "two", "three", "four"]
-        current.range = (1..2)
-        expect(current.buffer.range.to_a).to eq(["two", "three"])
-      end
-    end
   end
 end

--- a/spec/neovim/remote_object_spec.rb
+++ b/spec/neovim/remote_object_spec.rb
@@ -23,7 +23,7 @@ module Neovim
       end
 
       describe "#method_missing" do
-        it "enables window_* function calls" do
+        it "enables nvim_win_* function calls" do
           expect(window.get_cursor).to eq([1, 0])
         end
 
@@ -61,7 +61,7 @@ module Neovim
       end
 
       describe "#method_missing" do
-        it "enables tabpage_* function calls" do
+        it "enables nvim_tabpage_* function calls" do
           expect(tabpage.is_valid).to be(true)
         end
       end
@@ -72,7 +72,7 @@ module Neovim
         end
 
         it "returns api methods" do
-          expect(tabpage.methods).to include(:get_windows)
+          expect(tabpage.methods).to include(:list_wins)
         end
       end
     end
@@ -95,7 +95,7 @@ module Neovim
       end
 
       describe "#method_missing" do
-        it "enables buffer_* function calls" do
+        it "enables nvim_buf_* function calls" do
           expect(buffer.line_count).to be(1)
         end
       end

--- a/spec/neovim/ruby_provider/buffer_ext_spec.rb
+++ b/spec/neovim/ruby_provider/buffer_ext_spec.rb
@@ -13,7 +13,7 @@ module Neovim
 
     describe ".current" do
       it "returns the current buffer from the global Vim client" do
-        expect(Buffer.current).to eq(nvim.get_current_buffer)
+        expect(Buffer.current).to eq(nvim.get_current_buf)
       end
     end
 
@@ -27,9 +27,9 @@ module Neovim
 
     describe ".[]" do
       it "returns the buffer from the global Vim client at the given index" do
-        expect(Buffer[0]).to eq(nvim.get_current_buffer)
+        expect(Buffer[0]).to eq(nvim.get_current_buf)
         nvim.command("new")
-        expect(Buffer[1]).to eq(nvim.get_current_buffer)
+        expect(Buffer[1]).to eq(nvim.get_current_buf)
       end
     end
   end

--- a/spec/neovim/ruby_provider/window_ext_spec.rb
+++ b/spec/neovim/ruby_provider/window_ext_spec.rb
@@ -13,7 +13,7 @@ module Neovim
 
     describe ".current" do
       it "returns the current window from the global Vim client" do
-        expect(Window.current).to eq(nvim.get_current_window)
+        expect(Window.current).to eq(nvim.get_current_win)
       end
     end
 

--- a/spec/neovim/session/event_loop_spec.rb
+++ b/spec/neovim/session/event_loop_spec.rb
@@ -83,7 +83,7 @@ module Neovim
       context "child" do
         it "sends and receives data" do
           event_loop = EventLoop.child(Support.child_argv)
-          input = MessagePack.pack([0, 0, :vim_strwidth, ["hi"]])
+          input = MessagePack.pack([0, 0, :nvim_strwidth, ["hi"]])
 
           response = nil
           event_loop.write(input).run do |msg|

--- a/spec/neovim/session_spec.rb
+++ b/spec/neovim/session_spec.rb
@@ -17,56 +17,56 @@ module Neovim
 
       describe "#request" do
         it "synchronously returns a result" do
-          expect(session.request(:vim_strwidth, "foobar")).to be(6)
+          expect(session.request(:nvim_strwidth, "foobar")).to be(6)
         end
 
         it "raises an exception when there are errors" do
           expect {
-            session.request(:vim_strwidth, "too", "many")
+            session.request(:nvim_strwidth, "too", "many")
           }.to raise_error(/wrong number of arguments/i)
         end
 
         it "handles large data" do
           large_str = Array.new(1024 * 17) { SecureRandom.hex(1) }.join
-          session.request(:vim_set_current_line, large_str)
-          expect(session.request(:vim_get_current_line)).to eq(large_str)
+          session.request(:nvim_set_current_line, large_str)
+          expect(session.request(:nvim_get_current_line)).to eq(large_str)
         end
 
         it "fails outside of the main thread" do
           expect {
-            Thread.new { session.request(:vim_strwidth, "foo") }.join
+            Thread.new { session.request(:nvim_strwidth, "foo") }.join
           }.to raise_error(/outside of the main thread/)
         end
       end
 
       describe "#notify" do
         it "returns nil" do
-          expect(session.notify(:vim_input, "jk")).to be(nil)
+          expect(session.notify(:nvim_input, "jk")).to be(nil)
         end
 
         it "doesn't raise exceptions" do
           expect {
-            session.notify(:vim_strwidth, "too", "many")
+            session.notify(:nvim_strwidth, "too", "many")
           }.not_to raise_error
         end
 
         it "handles large data" do
           large_str = Array.new(1024 * 17) { SecureRandom.hex(1) }.join
-          session.notify(:vim_set_current_line, large_str)
-          expect(session.request(:vim_get_current_line)).to eq(large_str)
+          session.notify(:nvim_set_current_line, large_str)
+          expect(session.request(:nvim_get_current_line)).to eq(large_str)
         end
 
         it "fails outside of the main thread" do
           expect {
-            Thread.new { session.notify(:vim_set_current_line, "foo") }.join
+            Thread.new { session.notify(:nvim_set_current_line, "foo") }.join
           }.to raise_error(/outside of the main thread/)
         end
       end
 
       describe "#run" do
         it "enqueues messages received during blocking requests" do
-          session.request(:vim_subscribe, "my_event")
-          session.request(:vim_command, "call rpcnotify(0, 'my_event', 'foo')")
+          session.request(:nvim_subscribe, "my_event")
+          session.request(:nvim_command, "call rpcnotify(0, 'my_event', 'foo')")
 
           message = nil
           session.run do |msg|
@@ -80,12 +80,12 @@ module Neovim
         end
 
         it "supports requests within callbacks" do
-          session.request(:vim_subscribe, "my_event")
-          session.request(:vim_command, "call rpcnotify(0, 'my_event', 'foo')")
+          session.request(:nvim_subscribe, "my_event")
+          session.request(:nvim_command, "call rpcnotify(0, 'my_event', 'foo')")
 
           result = nil
           session.run do |msg|
-            result = session.request(:vim_strwidth, msg.arguments.first)
+            result = session.request(:nvim_strwidth, msg.arguments.first)
             session.shutdown
           end
 


### PR DESCRIPTION
This is a backwards incompatible change to bring the library to use the most up-to-date methods on the `nvim` RPC API. It also removes some cruft in the overall interface (mainly around the LineRange object).