### PR TITLE
Add missing require for tempfile for integration_spec

### DIFF
--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -5,6 +5,7 @@ require "helper"
 require "json"
 require "net/http"
 require "open-uri"
+require "tempfile"
 
 RSpec.describe "integration tests", :timeout => 30 do
   let(:root) { File.expand_path("../integration", __FILE__) }


### PR DESCRIPTION
I looked at your build logs and it seems to build fine, however here with Ruby 2.3 and 2.4 I am getting these errors:

```
     NameError:
       uninitialized constant Tempfile
     # ./spec/integration_spec.rb:110:in `run_vader'
     # ./spec/integration_spec.rb:68:in `block (4 levels) in <top (required)>'
     # ./spec/integration_spec.rb:15:in `block (3 levels) in <top (required)>'
     # ./spec/integration_spec.rb:15:in `chdir'
     # ./spec/integration_spec.rb:15:in `block (2 levels) in <top (required)>'
     # ./spec/helper.rb:32:in `block (3 levels) in <top (required)>'
     # ./spec/helper.rb:32:in `block (2 levels) in <top (required)>'
```

Simplying requiring 'tempfile' at the top fixes it for me.